### PR TITLE
Fix diffusion loss and arg parser default

### DIFF
--- a/src/models/ddpm.py
+++ b/src/models/ddpm.py
@@ -116,10 +116,10 @@ class DiffusionModel(nn.Module):
         return xt_minus_1, predicted_noise, noise
     
     def loss_function(self, x0, t):
-
-        loss = F.mse_loss()
-
-        return 
+        """Compute training loss for a given input and timestep."""
+        _, predicted_noise, noise = self.forward(x0, t)
+        loss = F.mse_loss(predicted_noise, noise)
+        return loss
 
     def sample(self, shape, device):
 

--- a/src/utils/args_utils.py
+++ b/src/utils/args_utils.py
@@ -8,7 +8,7 @@ def train_arg_parser():
     parser.add_argument('--exp_id',type=str, default='exp/0')
     parser.add_argument('--wandb', action='store_true', help='If true run wandb logger')
     parser.add_argument('--seed',type=int, default=42)
-    parser.add_argument('--lr', type=float, default='3e-3')
+    parser.add_argument('--lr', type=float, default=3e-3)
     parser.add_argument('--bs', type=int, default=30)
     parser.add_argument('--epoch', type=int, default=500)
     parser.add_argument('--test_size', type=float, default=0.05, help="If test_size is 0.05 then train_size is 0.95")


### PR DESCRIPTION
## Summary
- implement MSE loss in `DiffusionModel.loss_function`
- fix `--lr` default type in argument parser

## Testing
- `python -m py_compile src/models/ddpm.py src/utils/args_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6840d21fa8b0832e9d5386b61063d250