### PR TITLE
Fix README pip check typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ conda create -n new_env python==3.12.2
 conda activate new_env
 ```
 
-Check your your pip is the correct pip
+Check that your pip is the correct pip
 
 ```
 which pip


### PR DESCRIPTION
## Summary
- correct wording for pip verification in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d371094c832e84559e5b8d70ed9a